### PR TITLE
Use secure RubyGems source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
> The source :rubygems is deprecated because HTTP requests are insecure.

:yum:
