### PR TITLE
Remove require from gemspec

### DIFF
--- a/venice.gemspec
+++ b/venice.gemspec
@@ -1,13 +1,14 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "venice"
+lib_file = File.expand_path("../lib/venice.rb", __FILE__)
+File.read(lib_file) =~ /\bVERSION\s*=\s*["'](.+?)["']/
+version = $1
 
 Gem::Specification.new do |s|
   s.name        = "venice"
   s.authors     = ["Mattt Thompson"]
   s.email       = "m@mattt.me"
   s.homepage    = "http://github.com/mattt/venice"
-  s.version     = Venice::VERSION
+  s.version     = version
   s.platform    = Gem::Platform::RUBY
   s.summary     = "iTunes In-App Purchase Receipt Verification"
   s.description = ""


### PR DESCRIPTION
By requiring `lib/venice.rb` in the gemspec, it means all the gems in the bundle have to be installed before the bundle itself can be installed.

```
There was a LoadError while evaluating venice.gemspec: 
cannot load such file -- excon from
  /Users/Larry/Code/venice/venice.gemspec:3:in `<main>'

Does it try to require a relative path? That's been removed in Ruby 1.9.
```

There are numerous ways to pull in the version from a constant without requiring the entire library. I stole this from [faraday](https://github.com/lostisland/faraday/blob/75ab43c2ea6d27604b33c53e0a02cad5d600aa39/faraday.gemspec#L1-L4).
