### PR TITLE
Improved error handling

### DIFF
--- a/lib/venice.rb
+++ b/lib/venice.rb
@@ -1,3 +1,4 @@
 require 'venice/version'
+require 'venice/error'
 require 'venice/client'
 require 'venice/receipt'

--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -57,7 +57,7 @@ module Venice
 
         return receipt
       else
-        raise (RECEIPT_VERIFICATION_ERRORS_BY_STATUS_CODE[status] || "Unknown Error: #{status}")
+        raise Error.new(code: status, message: (RECEIPT_VERIFICATION_ERRORS_BY_STATUS_CODE[status] || "Unknown Error: #{status}"))
       end
     end
 

--- a/lib/venice/error.rb
+++ b/lib/venice/error.rb
@@ -1,0 +1,10 @@
+module Venice
+  class Error < StandardError
+    attr_accessor :code
+
+    def initialize(data)
+      @code = data[:code]
+      super(data[:message])
+    end
+  end
+end

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -90,8 +90,8 @@ module Venice
 
         begin
           client.verify!(data, options)
-        rescue => error
-          case error
+        rescue Venice::Error => error
+          case error.code
           when 21007
             client = Client.development
             retry


### PR DESCRIPTION
Hi,
I’ve seen that recently there was some changes in error handling, however, current apporach isn’t working properly:

With your code:

```
Venice::Receipt.verify!(Rails.root.join("spec","receipt").read)
RuntimeError: This receipt is a sandbox receipt, but it was sent to the production service for verification.
    from /Users/krzyzak/projects/venice/lib/venice/client.rb:60:in `verify!'
    from /Users/krzyzak/projects/venice/lib/venice/receipt.rb:92:in `verify!'
```

With my code:

```
Venice::Receipt.verify!(Rails.root.join("spec","receipt").read)

#<Venice::Receipt:0x007fe67bf9ca90 @quantity=1, @product_id="com.mindmobapp.download", @transaction_id="1000000046178817", @purchase_date=Mon, 30 Apr 2012 15:05:55 +0000, @app_item_id=nil, @version_external_identifier=nil, @bid="com.mindmobapp.MindMob", @bvrs="20120427", @original=#<Venice::Receipt:0x007fe67bf9c220 @product_id=nil, @transaction_id="1000000046178817", @purchase_date=Mon, 30 Apr 2012 15:05:55 +0000, @app_item_id=nil, @version_external_identifier=nil, @bid=nil, @bvrs=nil>
```

There are some failing tests (but originally were) – I don’t have time now to fix them, but I’m sure that I’ll try to fix them within few days ;)
