### PR TITLE
Require bundler in a standalone-friendly way

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
-require "bundler"
-Bundler.setup
+require 'bundler/setup'
 
 gemspec = eval(File.read("venice.gemspec"))
 


### PR DESCRIPTION
Requiring `bundler/setup` is a replacement for `Bundler.setup` with the added bonus of playing nicely with a standalone bundle (which I personally enjoy).
