### PR TITLE
Add shared secret option to Venice::Receipt.verify 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See Apple's [In-App Purchase Programming Guide](http://developer.apple.com/libra
 require 'venice'
 
 data = "(Base64-Encoded Receipt Data)"
-if receipt = Venice::Receipt.verify(data)
+if receipt = Venice::Receipt.verify(data, {:shared_secret => "mysecret"})
   p receipt.to_h
 end
 ```

--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -29,7 +29,7 @@ module Venice
     end
 
     def verify!(data, options = {})
-       @shared_secret = options[:shared_secret]
+      @shared_secret = options[:shared_secret]
       
       json = json_response_from_verifying_data(data)
       status, receipt_attributes = json['status'].to_i, json['receipt']


### PR DESCRIPTION
As far as I can tell there is currently no way to pass in the shared secret in Receipt.verify. There is an options hash but it does not appear to be used.
