### PR TITLE
Alter Receipt handling for iOS 7-style

### DIFF
--- a/bin/iap
+++ b/bin/iap
@@ -41,7 +41,20 @@ command :verify do |c|
       table = Terminal::Table.new :title => "Receipt" do |t|
         hash = receipt.to_h
         hash.keys.sort.each do |key|
+          next if key == :in_app
           t << [key, hash[key]]
+        end
+
+        if hash[:in_app]
+          index = 0
+          hash[:in_app].each do |iap|
+            index += 1
+            t << :separator
+            t << [:in_app, index]
+            iap.keys.sort.each do |key|
+              t << [" - #{key}", iap[key]]
+            end
+          end
         end
       end
 

--- a/lib/venice.rb
+++ b/lib/venice.rb
@@ -1,3 +1,4 @@
 require 'venice/version'
 require 'venice/client'
+require 'venice/in_app_receipt'
 require 'venice/receipt'

--- a/lib/venice/in_app_receipt.rb
+++ b/lib/venice/in_app_receipt.rb
@@ -1,0 +1,80 @@
+require 'time'
+
+module Venice
+  class InAppReceipt
+    # For detailed explanations on these keys/values, see
+    # https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW12
+
+    # The number of items purchased. This value corresponds to the quantity property of the SKPayment object stored in the transaction’s payment property.
+    attr_reader :quantity
+
+    # The product identifier of the item that was purchased. This value corresponds to the productIdentifier property of the SKPayment object stored in the transaction’s payment property.
+    attr_reader :product_id
+
+    # The transaction identifier of the item that was purchased. This value corresponds to the transaction’s transactionIdentifier property.
+    attr_reader :transaction_id
+
+    # The date and time this transaction occurred. This value corresponds to the transaction’s transactionDate property.
+    attr_reader :purchase_date
+
+    # A string that the App Store uses to uniquely identify the application that created the payment transaction. If your server supports multiple applications, you can use this value to differentiate between them. Applications that are executing in the sandbox do not yet have an app-item-id assigned to them, so this key is missing from receipts created by the sandbox.
+    attr_reader :app_item_id
+
+    # An arbitrary number that uniquely identifies a revision of your application. This key is missing in receipts created by the sandbox.
+    attr_reader :version_external_identifier
+
+    # For a transaction that restores a previous transaction, this is the original receipt
+    attr_accessor :original
+
+    # For auto-renewable subscriptions, returns the date the subscription will expire
+    attr_reader :expires_at
+
+    # For a transaction that was canceled by Apple customer support, the time and date of the cancellation.
+    attr_reader :cancellation_at
+
+
+    def initialize(attributes = {})
+      @quantity = Integer(attributes['quantity']) if attributes['quantity']
+      @product_id = attributes['product_id']
+      @transaction_id = attributes['transaction_id']
+      @purchase_date = DateTime.parse(attributes['purchase_date']) if attributes['purchase_date']
+      @app_item_id = attributes['app_item_id']
+      @version_external_identifier = attributes['version_external_identifier']
+
+      # expires_date is in ms since the Epoch, Time.at expects seconds
+      @expires_at = Time.at(attributes['expires_date'].to_i / 1000) if attributes['expires_date']
+      # cancellation_date is in ms since the Epoch, Time.at expects seconds
+      @cancellation_date = Time.at(attributes['cancellation_date'].to_i / 1000) if attributes['cancellation_date']
+
+      if attributes['original_transaction_id'] || attributes['original_purchase_date']
+        original_attributes = {
+          'transaction_id' => attributes['original_transaction_id'],
+          'purchase_date' => attributes['original_purchase_date']
+        }
+
+        self.original = InAppReceipt.new(original_attributes)
+      end
+
+    end
+
+    def to_h
+      {
+        :quantity => @quantity,
+        :product_id => @product_id,
+        :transaction_id => @transaction_id,
+        :purchase_date => (@purchase_date.httpdate rescue nil),
+        :original_transaction_id => (@original.transaction_id rescue nil),
+        :original_purchase_date => (@original.purchase_date.httpdate rescue nil),
+        :app_item_id => @app_item_id,
+        :version_external_identifier => @version_external_identifier,
+        :expires_at => (@expires_at.httpdate rescue nil),
+        :cancellation_at => (@cancellation_at.httpdate rescue nil)
+      }
+    end
+
+    def to_json
+      self.to_h.to_json
+    end
+
+  end
+end

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -40,7 +40,7 @@ module Venice
       if attributes['in_app']
         @in_app = []
         attributes['in_app'].each do |in_app_purchase_attributes|
-          @in_app <<  InAppReceipt.new(in_app_purchase_attributes)
+          @in_app << InAppReceipt.new(in_app_purchase_attributes)
         end
       end
 
@@ -56,7 +56,7 @@ module Venice
         :adam_id => @adam_id,
         :download_id => @download_id,
         :requested_at => (@requested_at.httpdate rescue nil),
-        :in_app => @in_app
+        :in_app => @in_app.map{|iap| iap.to_h }
       }
     end
 


### PR DESCRIPTION
I know this probably won't get merged as is due to it's non-backwards compatibility. But I did want to create a starting point for iOS 7 style receipt verification.