### PR TITLE
Improvements and fixes for Auto-Renewable Subscription

### DIFF
--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -43,7 +43,11 @@ module Venice
         # > Only returned for iOS 6 style transaction receipts for auto-renewable subscriptions.
         # > The JSON representation of the receipt for the most recent renewal
         if latest_receipt_info_attributes = json['latest_receipt_info']
-          receipt.latest_receipt = Receipt.new(latest_receipt_info_attributes)
+          # Apple sandbox retunrs 'latest_receipt_info' even if we use over iOS 6.
+          # Besides, its format is not Hash but Array so Receipt.new would fail.
+          if latest_receipt_info_attributes.is_a? Hash
+            receipt.latest_receipt = Receipt.new(latest_receipt_info_attributes)
+          end
         end
 
         return receipt

--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -30,6 +30,7 @@ module Venice
 
     def verify!(data, options = {})
       @verification_url ||= ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT
+      @shared_secret = options[:shared_secret] if options[:shared_secret]
 
       json = json_response_from_verifying_data(data)
       status, receipt_attributes = json['status'].to_i, json['receipt']

--- a/lib/venice/in_app_receipt.rb
+++ b/lib/venice/in_app_receipt.rb
@@ -52,7 +52,8 @@ module Venice
       @version_external_identifier = attributes['version_external_identifier']
 
       # expires_date is in ms since the Epoch, Time.at expects seconds
-      @expires_at = Time.at(attributes['expires_date'].to_i / 1000) if attributes['expires_date']
+      @expires_at = Time.at(attributes['expires_date_ms'].to_i / 1000) if attributes['expires_date_ms']
+
       # cancellation_date is in ms since the Epoch, Time.at expects seconds
       @cancellation_date = Time.at(attributes['cancellation_date'].to_i / 1000) if attributes['cancellation_date']
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -24,17 +24,35 @@ describe Venice::Client do
       let(:secret) { "shhhhhh" }
 
       before do
-        client.shared_secret = secret
         Venice::Receipt.stub :new
       end
 
-      it "should include the secret in the post" do
-        Net::HTTP.any_instance.should_receive(:request) do |post|
-          post.body.should eq({'receipt-data' => receipt_data, 'password' => secret}.to_json)
-          post
+      context "set secret manually" do
+        before do
+          client.shared_secret = secret
         end
-        client.verify! receipt_data
+
+        it "should include the secret in the post" do
+          Net::HTTP.any_instance.should_receive(:request) do |post|
+            post.body.should eq({'receipt-data' => receipt_data, 'password' => secret}.to_json)
+            post
+          end
+          client.verify! receipt_data
+        end
       end
+
+      context "set secret when verification" do
+        let(:options) { {shared_secret: secret}  }
+
+        it "should include the secret in the post" do
+          Net::HTTP.any_instance.should_receive(:request) do |post|
+            post.body.should eq({'receipt-data' => receipt_data, 'password' => secret}.to_json)
+            post
+          end
+          client.verify! receipt_data, options
+        end
+      end
+
     end
 
     context "with a latest receipt info attribute" do

--- a/spec/in_app_receipt_spec.rb
+++ b/spec/in_app_receipt_spec.rb
@@ -19,7 +19,8 @@ describe Venice::InAppReceipt do
         "is_trial_period" => false,
         "version_external_identifier" => "123",
         "app_item_id" => 'com.foo.app1',
-        "expires_date" => "2014-06-28 07:47:53 America/Los_Angeles"
+        "expires_date" => "2014-06-28 07:47:53 America/Los_Angeles",
+        "expires_date_ms" => "1403941673000"
       }
     end
 


### PR DESCRIPTION
Hello @kattrali @mattt (Sorry, I'm not sure who to mention!).

I'm developing an iOS app that includes a feature to use Auto-Renewable Subscription, with greatly helpful library `venice`. Then I found some issues and fixed / improved them.

Let me explain the changes.

1. Enable to pass **shared_secret** as `options`.

  As you know, Apple requires **shared secret** when verifying Auto-Renewale subscription. Though `venice` already enables me to pass the value [by `attr_writer`](https://github.com/nomad/venice/blob/master/lib/venice/client.rb#L11), it's more helpful to pass the value as an argument of `Venice::Client.verify!`. With this change, we can also pass it from `Venice::Receipt.verify!`.

  ```rb
Venice::Receipt.verify!(data, shared_secret: 'value')
```

1. Ignore obsolete attribute `latest_receipt_info` when its format is unexpected.

  I've tested my app with Apple's sandbox and disappointed that the sandbox returns unexpected `latest_receipt_info`... Its format is not `Hash` but `Array`, so `Receipt.new` [here](https://github.com/nomad/venice/blob/master/lib/venice/client.rb#L45) always fail. So I made `latest_receipt_info` would be ignored when the format is not `Hash`.

1. Use not `expires_date` but `expires_date_ms` to calculate date.

  Now `venice` considers [`expires_date` in `in_app` as milliseconds](https://github.com/nomad/venice/blob/master/lib/venice/in_app_receipt.rb#L55) but its format is a string like `2016-05-19 11:45:59 Etc/GMT`. We must use `expires_date_ms`.

These changes worked well with my app and I believe it could help other users of `venice`.
I'm in favor of that you review this PR and merge, thank you!