### PR TITLE
Change @cancellation_date to @cancellation_at

### DIFF
--- a/lib/venice/in_app_receipt.rb
+++ b/lib/venice/in_app_receipt.rb
@@ -55,7 +55,7 @@ module Venice
       @expires_at = Time.at(attributes['expires_date_ms'].to_i / 1000) if attributes['expires_date_ms']
 
       # cancellation_date is in ms since the Epoch, Time.at expects seconds
-      @cancellation_date = Time.at(attributes['cancellation_date'].to_i / 1000) if attributes['cancellation_date']
+      @cancellation_at = Time.at(attributes['cancellation_date'].to_i / 1000) if attributes['cancellation_date']
 
       if attributes['original_transaction_id'] || attributes['original_purchase_date']
         original_attributes = {


### PR DESCRIPTION
It looks like the incorrect cancellation variable name is referenced in `Venice::InAppReceipt`. I've looked all over to find an example response with cancellation date but haven't had any luck. The closest thing I can find is the [Apple documentation](https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW19) that says the field is an RFC 3339 date. If that's the case, it's being parsed incorrectly.

If someone can confirm that's the case, and verify if there's a cancellation_date_ms field, I'd be happy to update and write some tests for that.
