### PR TITLE
Update link to Apple's Programming Guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Venice is a simple gem for verifying Apple In-App Purchase receipts, and retriev
 
 There are two reasons why you should verify in-app purchase receipts on the server: First, it allows you to keep your own records of past purchases, which is useful for up-to-the-minute metrics and historical analysis. Second, server-side verification over SSL is the most reliable way to determine the authenticity of purchasing records.
 
-See Apple's [In-App Purchase Programming Guide](http://developer.apple.com/library/ios/#documentation/NetworkingInternet/Conceptual/StoreKitGuide/VerifyingStoreReceipts/VerifyingStoreReceipts.html) for additional information.
+See Apple's [Receipt Validation Programming Guide](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Introduction.html) for additional information.
 
 > Venice is named for [Venice, Italy](http://en.wikipedia.org/wiki/Venice,_Italy)—or more specifically, Shakespeare's [_The Merchant of Venice_](http://en.wikipedia.org/wiki/The_Merchant_of_Venice).
 > It's part of a series of world-class command-line utilities for iOS development, which includes [Cupertino](https://github.com/mattt/cupertino) (Apple Dev Center management), [Shenzhen](https://github.com/mattt/shenzhen) (Building & Distribution), [Houston](https://github.com/mattt/houston) (Push Notifications), [Dubai](https://github.com/mattt/dubai) (Passbook pass generation), and [Nashville](https://github.com/nomad/nashville) (iTunes Store API).


### PR DESCRIPTION
Hi,
the current README's link is no longer available from Apple's side. Regarding the old title of the link, Apple's current destination for it would be [In-App Purchase Programming Guide](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Introduction.html). But I guess for this topic, [Receipt Validation Programming Guide](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Introduction.html) is more relevant?

Besides that, thanx for your great work 🙏 

_(looking at Apple's [docs revision history](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/RevisionHistory.html) they seem to have merged different guides)_
