### PR TITLE
Code 21010 is not unknown

### DIFF
--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -132,6 +132,8 @@ module Venice
             "This receipt is a sandbox receipt, but it was sent to the production service for verification."
           when 21008
             "This receipt is a production receipt, but it was sent to the sandbox service for verification."
+          when 21010
+            "This receipt could not be authorized. Treat this the same as if a purchase was never made."
           else
             "Unknown Error: #{@code}"
         end


### PR DESCRIPTION
Hello @kattrali !

I found that my app raised an error with the following message.

```
Unknown Error: 21010
```

But accorging to [the official guide](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html#//apple_ref/doc/uid/TP40010573-CH104-SW4), it represents `This receipt could not be authorized. Treat this the same as if a purchase was never made.`. Then I added a code so that Venice can handle the code properly.