### PR TITLE
Enable to handle status code 21100..21199

### DIFF
--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -150,6 +150,8 @@ module Venice
             "This receipt is a production receipt, but it was sent to the sandbox service for verification."
           when 21010
             "This receipt could not be authorized. Treat this the same as if a purchase was never made."
+          when 21100..21199
+            "Internal data access error."
           else
             "Unknown Error: #{@code}"
         end


### PR DESCRIPTION
Hello @dankimio .
This PR is the same as https://github.com/nomad/venice/pull/37.

According to the official guide, those error codes represent "Internal data access error."
ref: https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html#//apple_ref/doc/uid/TP40010573-CH104-SW4