### PR TITLE
Avoid receipt.original_json_response to self-reference itself (fixes #36)

### DIFF
--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -33,7 +33,7 @@ module Venice
       @shared_secret = options[:shared_secret] if options[:shared_secret]
 
       json = json_response_from_verifying_data(data)
-      status, receipt_attributes = json['status'].to_i, json['receipt']
+      status, receipt_attributes = json['status'].to_i, json['receipt'].dup
       receipt_attributes['original_json_response'] = json if receipt_attributes
 
       case status

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -5,6 +5,24 @@ describe Venice::Client do
   let(:client) { subject }
 
   describe "#verify!" do
+    context "with a receipt response" do
+      before do
+        client.stub(:json_response_from_verifying_data).and_return(response)
+      end
+
+      let(:response) do
+        {
+          'status' => 0,
+          'receipt' => {},
+        }
+      end
+
+      it "does not generate a self-referencing Hash" do
+        receipt = client.verify! 'asdf'
+        expect(receipt.original_json_response["receipt"]).not_to have_key("original_json_response")
+      end
+    end
+
     context "no shared_secret" do
       before do
         client.shared_secret = nil


### PR DESCRIPTION
## Background

After verifying a receipt data using Venice, I am interesting in serializing the `original_json_response` in order to persist it to database. This way, I won't have to issue another request to Apple's servers unless I decide to do so (to update the latest receipt info for example).
By serializing the `original_json_response`, I'm making sure to keep everything that was in the response body from Apple.

 ## Problem

Currently, trying to serialize the original response, as provided by `Venice::Reciept`, will fail:

```rb
receipt = Venice::Receipt.verify(receipt_data, shared_secret: password)
receipt.original_json_response.to_json
```

See:
https://github.com/nomad/venice/blob/11b0cf7615d2cc81865b8b2621c20c94e6aa3f87/lib/venice/client.rb#L36-L37

In its current state, the second line is equivalent to

```rb
json['receipt']['original_json_response'] = json
```

This makes it a self-reference, which cannot be serialized.

 ## Solution

By duplicating `json['receipt']` before inserting the whole `json` in it, I'm avoiding the self-reference.
I also wrote an RSpec test that breaks without my change, but passes after.