### PR TITLE
Add the original JSON response to VerificationError

### DIFF
--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -33,11 +33,10 @@ module Venice
       @shared_secret = options[:shared_secret] if options[:shared_secret]
 
       json = json_response_from_verifying_data(data)
-      status = json['status'].to_i
       receipt_attributes = json['receipt'].dup
       receipt_attributes['original_json_response'] = json if receipt_attributes
 
-      case status
+      case json['status'].to_i
       when 0, 21006
         receipt = Receipt.new(receipt_attributes)
 
@@ -55,7 +54,7 @@ module Venice
 
         return receipt
       else
-        raise Receipt::VerificationError.new(status, receipt)
+        raise Receipt::VerificationError.new(json)
       end
     end
 

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -121,16 +121,23 @@ module Venice
     end
 
     class VerificationError < StandardError
+      attr_accessor :json
       attr_accessor :code
-      attr_accessor :receipt
 
-      def initialize(code, receipt)
-        @code = Integer(code)
-        @receipt = receipt
+      def initialize(json)
+        @json = json
+      end
+
+      def code
+        Integer(json['status'])
+      end
+
+      def retryable?
+        json['is-retryable']
       end
 
       def message
-        case @code
+        case code
         when 21000
           'The App Store could not read the JSON object you provided.'
         when 21002
@@ -152,7 +159,7 @@ module Venice
         when 21100..21199
           'Internal data access error.'
         else
-          "Unknown Error: #{@code}"
+          "Unknown Error: #{code}"
         end
       end
     end


### PR DESCRIPTION
- remove the always nil `receipt` parameter
- get the response code from the json, instead of as an instance
variable
- add `retryable?` method based on Apple's documentation
- add specs to confirm behavior

(See [Apple's
documentation](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html#//apple_ref/doc/uid/TP40010573-CH104-SW5).)

I mainly wanted a way to know whether the error returned by Apple is retryable or not, and ended up cleaning a little bit more. :)