### PR TITLE
Check for nil before dup

### DIFF
--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -33,7 +33,7 @@ module Venice
       @shared_secret = options[:shared_secret] if options[:shared_secret]
 
       json = json_response_from_verifying_data(data)
-      receipt_attributes = json['receipt'].dup
+      receipt_attributes = json['receipt'].dup if json['receipt']
       receipt_attributes['original_json_response'] = json if receipt_attributes
 
       case json['status'].to_i


### PR DESCRIPTION
Three specs fail because of a new change. Failed examples:
```
rspec ./spec/client_spec.rb:32 # Venice::Client#verify! no shared_secret should only include the receipt_data
rspec ./spec/client_spec.rb:53 # Venice::Client#verify! with a shared secret set secret manually should include the secret in the post
rspec ./spec/client_spec.rb:65 # Venice::Client#verify! with a shared secret set secret when verification should include the secret in the post
```