### PR TITLE
Add alternate attribute to avoid undocumented field from Apple IAP verification response

### DIFF
--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -34,7 +34,11 @@ module Venice
 
       json = json_response_from_verifying_data(data)
       receipt_attributes = json['receipt'].dup if json['receipt']
-      receipt_attributes['original_json_response'] = json if receipt_attributes
+
+      if receipt_attributes
+        receipt_attributes['original_json_response'] = json
+        receipt_attributes['verified_endpoint_type'] = endpoint_type
+      end
 
       case json['status'].to_i
       when 0, 21006
@@ -55,6 +59,14 @@ module Venice
         return receipt
       else
         raise Receipt::VerificationError.new(json)
+      end
+    end
+
+    def endpoint_type
+      if verification_url == ITUNES_PRODUCTION_RECEIPT_VERIFICATION_ENDPOINT
+        :production
+      elsif verification_url == ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT
+        :development
       end
     end
 

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -37,6 +37,9 @@ module Venice
     # Information about the status of the customer's auto-renewable subscriptions
     attr_reader :pending_renewal_info
 
+    # The endpoint at which verification happened.
+    attr_reader :verified_endpoint_type
+
     def initialize(attributes = {})
       @original_json_response = attributes['original_json_response']
 
@@ -54,6 +57,7 @@ module Venice
       @adam_id = attributes['adam_id']
       @download_id = attributes['download_id']
       @requested_at = DateTime.parse(attributes['request_date']) if attributes['request_date']
+      @verified_endpoint_type = attributes['verified_endpoint_type']
 
       @in_app = []
       if attributes['in_app']

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -157,5 +157,15 @@ describe Venice::Client do
         end
       end
     end
+
+    context "verified environment" do
+      it "has correct endpoint_type" do
+        dev_client = Venice::Client.development
+        prod_client = Venice::Client.production
+
+        expect(dev_client.endpoint_type).to eq(:development)
+        expect(prod_client.endpoint_type).to eq(:production)
+      end
+    end
   end
 end

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -75,6 +75,10 @@ describe Venice::Receipt do
       it 'should create the receipt' do
         receipt.should_not be_nil
       end
+
+      it "has the correct verified_endpoint_type" do
+        expect(receipt.verified_endpoint_type).to eq(:production)
+      end
     end
 
     it 'parses the pending rerenewal information' do


### PR DESCRIPTION
In its [Receipt validation documentation](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW1), Apple states that:

> Keys not documented below are reserved for use by Apple and must be ignored by your app.

Current implementation of `Receipt` has a `receipt_type` field to know if it's from production or sandbox. This is an undocumented field and can change anytime.

Given that this library deals with payments, it could be a critical component of a system. Any unexpected breaking because of a change in Apples's API response will have a big impact.

This PR tries to define a new attribute for `Receipt`, `verified_endpoint_type`. This is set independent of apple's api response. 
