### PR TITLE
Refactor a bit, and add an `environment` attribute to receipts

### DIFF
--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -29,6 +29,7 @@ module Venice
       when 0, 21006
         receipt = Receipt.new(
           attributes: json['receipt'],
+          environment: environment,
           original_json_response: json
         )
 

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -37,8 +37,8 @@ module Venice
     # Information about the status of the customer's auto-renewable subscriptions
     attr_reader :pending_renewal_info
 
-    def initialize(attributes = {})
-      @original_json_response = attributes['original_json_response']
+    def initialize(attributes: {}, original_json_response: {})
+      @original_json_response = original_json_response
 
       @bundle_id = attributes['bundle_id']
       @application_version = attributes['application_version']
@@ -94,7 +94,9 @@ module Venice
 
     class << self
       def verify(data, options = {})
-        verify!(data, options) rescue false
+        verify!(data, options)
+      rescue VerificationError
+        false
       end
 
       def verify!(data, options = {})

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -37,8 +37,12 @@ module Venice
     # Information about the status of the customer's auto-renewable subscriptions
     attr_reader :pending_renewal_info
 
-    def initialize(attributes: {}, original_json_response: {})
+    # AppStore environment from which the receipt was received
+    attr_reader :environment
+
+    def initialize(attributes: {}, environment: :production, original_json_response: {})
       @original_json_response = original_json_response
+      @environment = environment
 
       @bundle_id = attributes['bundle_id']
       @application_version = attributes['application_version']

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -25,7 +25,6 @@ describe Venice::Client do
 
     context 'no shared_secret' do
       before do
-        client.shared_secret = nil
         Venice::Receipt.stub :new
       end
 
@@ -34,7 +33,7 @@ describe Venice::Client do
           post.body.should eq({ 'receipt-data' => receipt_data }.to_json)
           post
         end
-        client.verify! receipt_data
+        client.verify! receipt_data, shared_secret: nil
       end
     end
 
@@ -46,16 +45,13 @@ describe Venice::Client do
       end
 
       context 'set secret manually' do
-        before do
-          client.shared_secret = secret
-        end
-
         it 'should include the secret in the post' do
           Net::HTTP.any_instance.should_receive(:request) do |post|
             post.body.should eq({ 'receipt-data' => receipt_data, 'password' => secret }.to_json)
             post
           end
-          client.verify! receipt_data
+          client.verify! receipt_data, shared_secret: secret
+
         end
       end
 

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -36,33 +36,31 @@ describe Venice::Receipt do
               'is_trial_period' => 'false'
             }
           ],
-          'original_json_response' => {
-            'pending_renewal_info' => [
-              {
-                'auto_renew_product_id' => 'com.foo.product1',
-                'original_transaction_id' => '37xxxxxxxxx89',
-                'product_id' => 'com.foo.product1',
-                'auto_renew_status' => '0',
-                'is_in_billing_retry_period' => '0',
-                'expiration_intent' => '1'
-              }
-            ]
+        },
+        'pending_renewal_info' => [
+          {
+            'auto_renew_product_id' => 'com.foo.product1',
+            'original_transaction_id' => '37xxxxxxxxx89',
+            'product_id' => 'com.foo.product1',
+            'auto_renew_status' => '0',
+            'is_in_billing_retry_period' => '0',
+            'expiration_intent' => '1'
           }
-        }
+        ]
       }
     end
 
-    subject { Venice::Receipt.new(response['receipt']) }
+    subject { Venice::Receipt.new(attributes: response['receipt']) }
 
-    its(:bundle_id) { 'com.foo.bar' }
-    its(:application_version) { '2' }
+    its(:bundle_id) { should eql 'com.foo.bar' }
+    its(:application_version) { should eql '2' }
     its(:in_app) { should be_instance_of Array }
-    its(:original_application_version) { '1' }
+    its(:original_application_version) { should eql '1' }
     its(:original_purchase_date) { should be_instance_of DateTime }
     its(:expires_at) { should be_instance_of DateTime }
-    its(:receipt_type) { 'Production' }
-    its(:adam_id) { 7654321 }
-    its(:download_id) { 1234567 }
+    its(:receipt_type) { should eql 'Production' }
+    its(:adam_id) { should eql 7654321 }
+    its(:download_id) { should eql 1234567 }
     its(:requested_at) { should be_instance_of DateTime }
 
     describe '#verify!' do
@@ -78,7 +76,9 @@ describe Venice::Receipt do
     end
 
     it 'parses the pending rerenewal information' do
-      expect(subject.to_hash[:pending_renewal_info]).to eql([{ expiration_intent: 1,
+      receipt = Venice::Receipt.new(attributes: response['receipt'], original_json_response: response)
+
+      expect(receipt.to_hash[:pending_renewal_info]).to eql([{ expiration_intent: 1,
                                                                auto_renew_status: 0,
                                                                auto_renew_product_id: 'com.foo.product1',
                                                                is_in_billing_retry_period: false,

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -62,6 +62,7 @@ describe Venice::Receipt do
     its(:adam_id) { should eql 7654321 }
     its(:download_id) { should eql 1234567 }
     its(:requested_at) { should be_instance_of DateTime }
+    its(:environment) { should eq :production }
 
     describe '#verify!' do
       before do


### PR DESCRIPTION
This is an alternative suggestion for #45.

As @aqeelvn mentions in the other PR, our only way, in Venice's current implementation, to know if a receipt is sandbox or production, is to check the receipt's `receipt_type` key, from Apple's response. This key is actually not documented, so its use should be avoided as much as possible.

> Keys not documented below are reserved for use by Apple and must be ignored by your app.
> _([Source](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW1).)_

Instead, it would be appreciable to surface at the `Receipt` level which Apple API endpoint ultimately verified the receipt successfully.

To achieve that, I had to do a bit of refactoring at the `Client` level. I also fixed the code in a few specs, so that they have more meaning.

Feel free to have a look at the inline comments I left in the code.

Please note that it may be necessary to increment the major version number as some of the changes I propose break public APIs:

- `Client.new` now takes parameters in.
- `Client.verification_url=` is not available anymore (you need to pass an environment, and/or a verification URL in initialization)
- `Client.shared_secret=` is not available anymore. `shared_secret` is a parameter to the `verify` methods.
- `Receipt.new` takes extra arguments to set `environment` and `original_json_response`