### PR TITLE
Allow the calling application to define timeouts on the request to the Apple Store

### DIFF
--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -94,7 +94,9 @@ module Venice
 
     class << self
       def verify(data, options = {})
-        verify!(data, options) rescue false
+        verify!(data, options)
+      rescue VerificationError, Client::TimeoutError
+        false
       end
 
       def verify!(data, options = {})


### PR DESCRIPTION
`Net::HTTP`'s default `read_timeout` and `open_timeout` values are 60 seconds.
This is extremely long, and in the case of the application we are working on, we would prefer to set shorter timeouts and fail early (then retry if necessary).

This PR proposes a way to set timeout values in the `Venice::Receipt.verify` call.