### PR TITLE
Add receipt_created_at field

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Venice also comes with the `iap` binary, which provides a convenient way to veri
     | original_application_version   | 123                                |
     | original_purchase_date         | Fri, 07 Mar 2014 20:59:24 GMT      |
     | receipt_type                   | Production                         |
+    | receipt_created_at             | Mon, 23 Jun 2014 17:59:38 GMT      |
     | requested_at                   | Mon, 23 Jun 2014 17:59:38 GMT      |
     +--------------------------------+------------------------------------+
     | in_app                         | 1                                  |

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -28,6 +28,7 @@ module Venice
     attr_reader :adam_id
     attr_reader :download_id
     attr_reader :requested_at
+    attr_reader :receipt_created_at
 
     # Original json response from AppStore
     attr_reader :original_json_response
@@ -54,6 +55,7 @@ module Venice
       @adam_id = attributes['adam_id']
       @download_id = attributes['download_id']
       @requested_at = DateTime.parse(attributes['request_date']) if attributes['request_date']
+      @receipt_created_at = DateTime.parse(attributes['receipt_creation_date']) if attributes['receipt_creation_date']
 
       @in_app = []
       if attributes['in_app']
@@ -81,6 +83,7 @@ module Venice
         adam_id: @adam_id,
         download_id: @download_id,
         requested_at: (@requested_at.httpdate rescue nil),
+        receipt_created_at: (@receipt_created_at.httpdate rescue nil),
         in_app: @in_app.map(&:to_h),
         pending_renewal_info: @pending_renewal_info.map(&:to_h),
         latest_receipt_info: @latest_receipt_info

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -12,6 +12,9 @@ describe Venice::Receipt do
           'bundle_id' => 'com.foo.bar',
           'application_version' => '2',
           'download_id' => 1234567,
+          'receipt_creation_date' => '2014-06-04 23:20:47 Etc/GMT',
+          'receipt_creation_date_ms' => '1401924047883',
+          'receipt_creation_date_pst' => '2014-06-04 16:20:47 America/Los_Angeles',
           'request_date' => '2014-06-04 23:20:47 Etc/GMT',
           'request_date_ms' => '1401924047883',
           'request_date_pst' => '2014-06-04 16:20:47 America/Los_Angeles',
@@ -61,6 +64,7 @@ describe Venice::Receipt do
     its(:original_purchase_date) { should be_instance_of DateTime }
     its(:expires_at) { should be_instance_of DateTime }
     its(:receipt_type) { 'Production' }
+    its(:receipt_created_at) { should be_instance_of DateTime }
     its(:adam_id) { 7654321 }
     its(:download_id) { 1234567 }
     its(:requested_at) { should be_instance_of DateTime }


### PR DESCRIPTION
Add a `receipt_created_at` field from Apple Receipt Fields `receipt_creation_date` mentioned in: https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html