### PR TITLE
Fix typo

### DIFF
--- a/lib/venice/pending_renewal_info.rb
+++ b/lib/venice/pending_renewal_info.rb
@@ -34,7 +34,7 @@ module Venice
       @auto_renew_product_id = attributes['auto_renew_product_id']
 
       if attributes['is_in_billing_retry_period']
-        @is_in_billing_retry_period = (attributes[is_in_billing_retry_period] == '1')
+        @is_in_billing_retry_period = (attributes['is_in_billing_retry_period'] == '1')
       end
 
       @product_id = attributes['product_id']


### PR DESCRIPTION
#55 
`is_in_billing_retry_period` is nil, so instead of accessing the right attribute value it was checking for `attributes[nil]`, causing `@is_in_billing_retry_period` value to always be `false`.