### PR TITLE
Fix issues with iOS 6 style auto-renewable receipts

### DIFF
--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -46,6 +46,8 @@ module Venice
         # > Only returned for iOS 6 style transaction receipts for auto-renewable subscriptions.
         # > The JSON representation of the receipt for the most recent renewal
         if latest_receipt_info_attributes = json['latest_receipt_info']
+          latest_receipt_info_attributes = [latest_receipt_info_attributes] if latest_receipt_info_attributes.is_a?(Hash)
+
           # AppStore returns 'latest_receipt_info' even if we use over iOS 6. Besides, its format is an Array.
           receipt.latest_receipt_info = []
           latest_receipt_info_attributes.each do |latest_receipt_info_attribute|

--- a/lib/venice/in_app_receipt.rb
+++ b/lib/venice/in_app_receipt.rb
@@ -51,7 +51,11 @@ module Venice
       @version_external_identifier = attributes['version_external_identifier']
 
       # expires_date is in ms since the Epoch, Time.at expects seconds
-      @expires_at = Time.at(attributes['expires_date_ms'].to_i / 1000) if attributes['expires_date_ms']
+      if attributes['expires_date_ms']
+        @expires_at = Time.at(attributes['expires_date_ms'].to_i / 1000) 
+      elsif attributes['expires_date'] && is_number?(attributes['expires_date'])
+        @expires_at = Time.at(attributes['expires_date'].to_i / 1000)
+      end
 
       # cancellation_date is in ms since the Epoch, Time.at expects seconds
       @cancellation_at = Time.at(attributes['cancellation_date_ms'].to_i / 1000) if attributes['cancellation_date_ms']
@@ -84,6 +88,12 @@ module Venice
 
     def to_json
       to_hash.to_json
+    end
+    
+    private
+    
+    def is_number?(string)
+      !!(string && string.to_s =~ /^[0-9]+$/)
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -73,10 +73,6 @@ describe Venice::Client do
     end
 
     context 'with a latest receipt info attribute' do
-      before do
-        client.stub(:json_response_from_verifying_data).and_return(response)
-      end
-
       let(:response) do
         {
           'status' => 0,
@@ -108,8 +104,20 @@ describe Venice::Client do
       end
 
       it 'should create a latest receipt' do
+        client.stub(:json_response_from_verifying_data).and_return(response)
         receipt = client.verify! 'asdf'
         receipt.latest_receipt_info.should_not be_nil
+        receipt.latest_receipt_info.first.product_id.should eq 'com.ficklebits.nsscreencast.monthly_sub'
+      end
+      
+      context 'when latest_receipt_info is a hash instead of an array' do
+        it 'should still create a latest receipt' do
+          response['latest_receipt_info'] = response['latest_receipt_info'].first
+          client.stub(:json_response_from_verifying_data).and_return(response)
+          receipt = client.verify! 'asdf'
+          receipt.latest_receipt_info.should_not be_nil
+          receipt.latest_receipt_info.first.product_id.should eq 'com.ficklebits.nsscreencast.monthly_sub'
+        end
       end
     end
 

--- a/spec/in_app_receipt_spec.rb
+++ b/spec/in_app_receipt_spec.rb
@@ -40,6 +40,12 @@ describe Venice::InAppReceipt do
       subject.original.transaction_id.should == '140xxx867509'
       subject.original.purchased_at.should be_instance_of DateTime
     end
+    
+    it "should parse expires_date when expires_date_ms is missing and expires_date is the ms epoch" do
+      attributes.delete('expires_date_ms')
+      attributes['expires_date'] = '1403941685000'
+      in_app_receipt.expires_at.should eq Time.at(1403941685000 / 1000)
+    end
 
     it 'should output a hash with attributes' do
       in_app_receipt.to_h.should include(quantity: 1,


### PR DESCRIPTION
Fixes #33

This PR address two issues. 

First, as noted in #33, when verifying iOS 6 style auto-renewable receipts, `latest_receipt_info` is a hash, not an array. The code was expecting an array and threw an error.

Second, this PR adds support for parsing the `expires_date` field in the in-app receipt, as [documented by Apple](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW1):

```
Subscription Expiration Date
The expiration date for the subscription, expressed as the number of milliseconds since January 1, 1970, 00:00:00 GMT.

ASN.1 Field Type 1708
ASN.1 Field Value IA5STRING, interpreted as an RFC 3339 date
JSON Field Name expires_date
JSON Field Value string, interpreted as an RFC 3339 date

This key is only present for auto-renewable subscription receipts. Use this value to identify the date when the subscription will renew or expire, to determine if a customer should have access to content or service. After validating the latest receipt, if the subscription expiration date for the latest renewal transaction is a past date, it is safe to assume that the subscription has expired.
```

My receipts do not have the `expires_date_ms` field, so `expires_at` was not getting set. I also noticed that `expires_date_ms` is not documented by Apple so should perhaps not be relied upon.

None of the changes made should be breaking changes, but are just fallbacks to handle the two scenarios mentioned above.