### PR TITLE
Bump Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.3
+  - 2.4.4
+  - 2.5.1


### PR DESCRIPTION
It's been a while since Ruby 2.5 has been released. So I think it's better to run tests against Ruby 2.5 as well. What do you think?

- Update 2.4.3 to 2.4.4
- Add 2.5.1