### PR TITLE
parse is_in_intro_offer_period from auto-renewable subscription receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Venice also comes with the `iap` binary, which provides a convenient way to veri
     |  - web_order_line_item_id      | 1000000000000001                   |
     |  - version_external_identifier |                                    |
     |  - is_trial_period             | true                               |
+    |  - is_in_intro_offer_period    | true                               |
     +--------------------------------+------------------------------------+
 
 

--- a/lib/venice/in_app_receipt.rb
+++ b/lib/venice/in_app_receipt.rb
@@ -46,6 +46,10 @@ module Venice
     # For a transaction that was canceled by Apple customer support, the time and date of the cancellation.
     attr_reader :cancellation_at
 
+    # Only present for auto-renewable subscription receipts. Value is true if the customer’s subscription is
+    # currently in an introductory price period, false if not, nil if key is not present on receipt.
+    attr_reader :is_in_intro_offer_period
+
     def initialize(attributes = {})
       @quantity = Integer(attributes['quantity']) if attributes['quantity']
       @product_id = attributes['product_id']
@@ -55,6 +59,7 @@ module Venice
       @app_item_id = attributes['app_item_id']
       @version_external_identifier = attributes['version_external_identifier']
       @is_trial_period = attributes['is_trial_period'].to_s == 'true'
+      @is_in_intro_offer_period = attributes['is_in_intro_offer_period'] == 'true' if attributes['is_in_intro_offer_period']
 
       # expires_date is in ms since the Epoch, Time.at expects seconds
       if attributes['expires_date_ms']
@@ -88,6 +93,7 @@ module Venice
         app_item_id: @app_item_id,
         version_external_identifier: @version_external_identifier,
         is_trial_period: @is_trial_period,
+        is_in_intro_offer_period: @is_in_intro_offer_period,
         expires_at: (@expires_at.httpdate rescue nil),
         cancellation_at: (@cancellation_at.httpdate rescue nil)
       }

--- a/spec/in_app_receipt_spec.rb
+++ b/spec/in_app_receipt_spec.rb
@@ -16,6 +16,7 @@ describe Venice::InAppReceipt do
         'original_purchase_date_ms' => '1401288473000',
         'original_purchase_date_pst' => '2014-05-28 07:47:53 America/Los_Angeles',
         'is_trial_period' => 'false',
+        'is_in_intro_offer_period' => 'true',
         'version_external_identifier' => '123',
         'app_item_id' => 'com.foo.app1',
         'expires_date' => '2014-06-28 07:47:53 America/Los_Angeles',
@@ -35,6 +36,7 @@ describe Venice::InAppReceipt do
     its(:app_item_id) { 'com.foo.app1' }
     its(:version_external_identifier) { '123' }
     its(:is_trial_period) { false }
+    its(:is_in_intro_offer_period) { true }
     its(:original) { should be_instance_of Venice::InAppReceipt }
     its(:expires_at) { should be_instance_of Time }
 
@@ -56,6 +58,7 @@ describe Venice::InAppReceipt do
                                          transaction_id: '1000000070107235',
                                          web_order_line_item_id: '1000000026812043',
                                          is_trial_period: false,
+                                         is_in_intro_offer_period: true,
                                          purchase_date: 'Wed, 28 May 2014 14:47:53 GMT',
                                          original_purchase_date: 'Wed, 28 May 2014 14:47:53 GMT')
     end


### PR DESCRIPTION
In response to #61, @rlho added parsing for the `is_trial_period` attribute on InAppReceipt, (Thanks, I had gotten lazy!) but nothing for `is_in_intro_offer_period`. I cribbed all the style from that merged pull request and applied it to `is_in_intro_offer_period`, with the addition of a presence check on the base receipt data because true/false/nil each mean something different about the receipt.

I'm submitting a parallel pull request to make the distinction on is_trial_period.