### PR TITLE
#original_json_data method for InAppReceipt and PendingRenewalInfo objects

### DIFF
--- a/lib/venice/in_app_receipt.rb
+++ b/lib/venice/in_app_receipt.rb
@@ -5,6 +5,9 @@ module Venice
     # For detailed explanations on these keys/values, see
     # https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW12
 
+    # Original JSON data returned from Apple for an InAppReceipt object.
+    attr_reader :original_json_data
+
     # The number of items purchased. This value corresponds to the quantity property of
     # the SKPayment object stored in the transaction’s payment property.
     attr_reader :quantity
@@ -47,6 +50,7 @@ module Venice
     attr_reader :cancellation_at
 
     def initialize(attributes = {})
+      @original_json_data = attributes
       @quantity = Integer(attributes['quantity']) if attributes['quantity']
       @product_id = attributes['product_id']
       @transaction_id = attributes['transaction_id']

--- a/lib/venice/pending_renewal_info.rb
+++ b/lib/venice/pending_renewal_info.rb
@@ -1,5 +1,8 @@
 module Venice
   class PendingRenewalInfo
+    # Original JSON data returned from Apple for a PendingRenewalInfo object.
+    attr_reader :original_json_data
+
     # For an expired subscription, the reason for the subscription expiration.
     # This key is only present for a receipt containing an expired auto-renewable subscription.
     attr_reader :expiration_intent
@@ -29,6 +32,7 @@ module Venice
     attr_reader :cancellation_reason
 
     def initialize(attributes)
+      @original_json_data = attributes
       @expiration_intent = Integer(attributes['expiration_intent']) if attributes['expiration_intent']
       @auto_renew_status = Integer(attributes['auto_renew_status']) if attributes['auto_renew_status']
       @auto_renew_product_id = attributes['auto_renew_product_id']

--- a/spec/in_app_receipt_spec.rb
+++ b/spec/in_app_receipt_spec.rb
@@ -37,6 +37,7 @@ describe Venice::InAppReceipt do
     its(:is_trial_period) { false }
     its(:original) { should be_instance_of Venice::InAppReceipt }
     its(:expires_at) { should be_instance_of Time }
+    its(:original_json_data) { attributes }
 
     it "should parse the 'original' attributes" do
       subject.original.should be_instance_of Venice::InAppReceipt

--- a/spec/pending_renewal_info_spec.rb
+++ b/spec/pending_renewal_info_spec.rb
@@ -23,6 +23,7 @@ describe Venice::PendingRenewalInfo do
       expect(subject.auto_renew_product_id).to eql('com.foo.product1')
       expect(subject.is_in_billing_retry_period).to eql(false)
       expect(subject.product_id).to eql('com.foo.product1')
+      expect(subject.original_json_data).to eql(attributes)
     end
 
     it 'outputs attributes in hash' do


### PR DESCRIPTION
I'm bumping #62, this time with code in hand.

This commit adds #original_json_data to the InAppReceipt and PendingRenewalInfo classes. The purpose is when dealing with objects of those respective classes, a developer can see the original data in it's pre-parsed format without going back to to Receipt and digging through the nested lists.