### PR TITLE
Rescue from html responses to prevent parse errors

### DIFF
--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -95,13 +95,23 @@ module Venice
         raise TimeoutError
       end
 
-      JSON.parse(response.body)
+      begin
+        JSON.parse(response.body)
+      rescue JSON::ParserError
+        raise InvalidResponseError
+      end
     end
   end
 
   class Client::TimeoutError < Timeout::Error
     def message
       'The App Store timed out.'
+    end
+  end
+
+  class Client::InvalidResponseError < StandardError
+    def message
+      'The App Store returned invalid response'
     end
   end
 end


### PR DESCRIPTION
From time to time I get this error in production:

`JSON::ParserError: 784: unexpected token at '<html><body><b>Http/1.1 Service Unavailable</b></body> </html>'`

Apparently sometimes apple response for receipt verification is not `json` which causes this error. It would be great if we could handle such error somehow even if it's quite rare.