### PR TITLE
Bump Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.4
-  - 2.5.1
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0


### PR DESCRIPTION
Let's update Ruby versions if `venice` supports them.

ref https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/