### PR TITLE
Feature/solidify receipt initialization

### DIFF
--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -6,9 +6,6 @@ module Venice
   ITUNES_PRODUCTION_RECEIPT_VERIFICATION_ENDPOINT = 'https://buy.itunes.apple.com/verifyReceipt'
   ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT = 'https://sandbox.itunes.apple.com/verifyReceipt'
 
-  ITUNES_PRODUCTION_ENVIRONMENT = 'production'
-  ITUNES_DEVELOPMENT_ENVIRONMENT = 'development'
-
   class Client
     attr_accessor :verification_url, :env_name
     attr_writer :shared_secret
@@ -18,14 +15,14 @@ module Venice
       def development
         client = new
         client.verification_url = ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT
-        client.env_name = ITUNES_DEVELOPMENT_ENVIRONMENT
+        client.env_name = Venice::Receipt::EnvName::DEVELOPMENT
         client
       end
 
       def production
         client = new
         client.verification_url = ITUNES_PRODUCTION_RECEIPT_VERIFICATION_ENDPOINT
-        client.env_name = ITUNES_PRODUCTION_ENVIRONMENT
+        client.env_name = Venice::Receipt::EnvName::PRODUCTION
         client
       end
     end
@@ -37,7 +34,7 @@ module Venice
 
     def verify!(data, options = {})
       @verification_url ||= ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT
-      @env_name ||= ITUNES_DEVELOPMENT_ENVIRONMENT
+      @env_name ||= Venice::Receipt::EnvName::DEVELOPMENT
       @shared_secret = options[:shared_secret] if options[:shared_secret]
       @exclude_old_transactions = options[:exclude_old_transactions] if options[:exclude_old_transactions]
 

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -41,9 +41,13 @@ module Venice
     # Information about the status of the customer's auto-renewable subscriptions
     attr_reader :pending_renewal_info
 
+    # The environment on which the receipt has verified against
+    attr_reader :env_name
+
     def initialize(attributes = {})
       @original_json_response = attributes['original_json_response']
 
+      @env_name = attributes['env_name']
       @bundle_id = attributes['bundle_id']
       @application_version = attributes['application_version']
       @original_application_version = attributes['original_application_version']
@@ -59,7 +63,8 @@ module Venice
       @download_id = attributes['download_id']
       @requested_at = DateTime.parse(attributes['request_date']) if attributes['request_date']
       @receipt_created_at = DateTime.parse(attributes['receipt_creation_date']) if attributes['receipt_creation_date']
-      @expiration_intent = Integer(original_json_response['expiration_intent']) if original_json_response['expiration_intent']
+
+      @expiration_intent = Integer(original_json_response['expiration_intent']) if original_json_response && original_json_response['expiration_intent']
 
       @in_app = []
       if attributes['in_app']

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -83,6 +83,7 @@ module Venice
 
     def to_hash
       {
+        env_name: @env_name,
         bundle_id: @bundle_id,
         application_version: @application_version,
         original_application_version: @original_application_version,

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -4,6 +4,11 @@ module Venice
   class Receipt
     MAX_RE_VERIFY_COUNT = 3
 
+    module EnvName
+      DEVELOPMENT = 'development'
+      PRODUCTION = 'production'
+    end
+
     # For detailed explanations on these keys/values, see
     # https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW1
 
@@ -79,6 +84,14 @@ module Venice
           @pending_renewal_info << PendingRenewalInfo.new(pending_renewal_attributes)
         end
       end
+    end
+
+    def development?
+      env_name == Venice::Receipt::EnvName::DEVELOPMENT
+    end
+
+    def production?
+      env_name == Venice::Receipt::EnvName::PRODUCTION
     end
 
     def to_hash

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -106,6 +106,7 @@ describe Venice::Client do
       it 'should create a latest receipt' do
         client.stub(:json_response_from_verifying_data).and_return(response)
         receipt = client.verify! 'asdf'
+        receipt.env_name.should eq 'development'
         receipt.latest_receipt_info.should_not be_nil
         receipt.latest_receipt_info.first.product_id.should eq 'com.ficklebits.nsscreencast.monthly_sub'
       end

--- a/spec/fixtures/receipt_not_expired_cancelled.json
+++ b/spec/fixtures/receipt_not_expired_cancelled.json
@@ -34,18 +34,16 @@
         "expires_date": "2014-06-28 14:47:53 Etc/GMT",
         "is_trial_period": "false"
       }
-    ],
-    "original_json_response": {
-      "pending_renewal_info": [
-        {
-          "auto_renew_product_id": "com.foo.product1",
-          "original_transaction_id": "37xxxxxxxxx89",
-          "product_id": "com.foo.product1",
-          "auto_renew_status": "0",
-          "is_in_billing_retry_period": "0",
-          "expiration_intent": "1"
-        }
-      ]
+    ]
+  },
+  "pending_renewal_info": [
+    {
+      "auto_renew_product_id": "com.foo.product1",
+      "original_transaction_id": "37xxxxxxxxx89",
+      "product_id": "com.foo.product1",
+      "auto_renew_status": "0",
+      "is_in_billing_retry_period": "0",
+      "expiration_intent": "1"
     }
-  }
+  ]
 }

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -68,6 +68,10 @@ describe Venice::Receipt do
           end
 
           its(:env_name) { is_expected.to eq 'production' }
+
+          its(:production?) { is_expected.to be true }
+
+          its(:development?) { is_expected.to be false }
         end
 
         context 'with 4 retryable error responses' do
@@ -122,6 +126,10 @@ describe Venice::Receipt do
           end
 
           its(:env_name) { is_expected.to eq 'development' }
+
+          its(:production?) { is_expected.to be false }
+
+          its(:development?) { is_expected.to be true }
         end
       end
 

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -4,7 +4,7 @@ describe Venice::Receipt do
   describe 'parsing the response' do
     let(:response) { JSON.parse(File.read('./spec/fixtures/receipt_not_expired_cancelled.json')) }
 
-    subject { Venice::Receipt.new(response['receipt']) }
+    subject { Venice::Receipt.new(response) }
 
     its(:bundle_id) { 'com.foo.bar' }
     its(:application_version) { '2' }


### PR DESCRIPTION
This is to be able to initialize receipt from response without any additional processing outside the constructor. 