### PR TITLE
Feature/solidify receipt initialization

### DIFF
--- a/lib/venice.rb
+++ b/lib/venice.rb
@@ -1,4 +1,5 @@
 require 'venice/version'
+require 'venice/environment'
 require 'venice/client'
 require 'venice/in_app_receipt'
 require 'venice/receipt'

--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -6,9 +6,6 @@ module Venice
   ITUNES_PRODUCTION_RECEIPT_VERIFICATION_ENDPOINT = 'https://buy.itunes.apple.com/verifyReceipt'
   ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT = 'https://sandbox.itunes.apple.com/verifyReceipt'
 
-  ITUNES_PRODUCTION_ENVIRONMENT = 'production'
-  ITUNES_DEVELOPMENT_ENVIRONMENT = 'development'
-
   class Client
     attr_accessor :verification_url, :env_name
     attr_writer :shared_secret
@@ -18,14 +15,14 @@ module Venice
       def development
         client = new
         client.verification_url = ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT
-        client.env_name = ITUNES_DEVELOPMENT_ENVIRONMENT
+        client.env_name = Venice::Receipt::EnvName::DEVELOPMENT
         client
       end
 
       def production
         client = new
         client.verification_url = ITUNES_PRODUCTION_RECEIPT_VERIFICATION_ENDPOINT
-        client.env_name = ITUNES_PRODUCTION_ENVIRONMENT
+        client.env_name = Venice::Receipt::EnvName::PRODUCTION
         client
       end
     end
@@ -37,7 +34,7 @@ module Venice
 
     def verify!(data, options = {})
       @verification_url ||= ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT
-      @env_name ||= ITUNES_DEVELOPMENT_ENVIRONMENT
+      @env_name ||= Venice::Receipt::EnvName::DEVELOPMENT
       @shared_secret = options[:shared_secret] if options[:shared_secret]
       @exclude_old_transactions = options[:exclude_old_transactions] if options[:exclude_old_transactions]
 

--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -3,11 +3,6 @@ require 'net/https'
 require 'uri'
 
 module Venice
-  class Environment < Struct.new(:name, :endpoint)
-    PRODUCTION = new('production', 'https://buy.itunes.apple.com/verifyReceipt')
-    DEVELOPMENT = new('development', 'https://sandbox.itunes.apple.com/verifyReceipt')
-  end
-
   class Client
     attr_accessor :verification_url, :environment
     attr_writer :shared_secret

--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -6,8 +6,13 @@ module Venice
   ITUNES_PRODUCTION_RECEIPT_VERIFICATION_ENDPOINT = 'https://buy.itunes.apple.com/verifyReceipt'
   ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT = 'https://sandbox.itunes.apple.com/verifyReceipt'
 
+  module Environment
+    PRODUCTION = 'production'
+    DEVELOPMENT = 'development'
+  end
+
   class Client
-    attr_accessor :verification_url, :env_name
+    attr_accessor :verification_url, :environment
     attr_writer :shared_secret
     attr_writer :exclude_old_transactions
 
@@ -15,31 +20,31 @@ module Venice
       def development
         client = new
         client.verification_url = ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT
-        client.env_name = Venice::Receipt::EnvName::DEVELOPMENT
+        client.environment = Environment::DEVELOPMENT
         client
       end
 
       def production
         client = new
         client.verification_url = ITUNES_PRODUCTION_RECEIPT_VERIFICATION_ENDPOINT
-        client.env_name = Venice::Receipt::EnvName::PRODUCTION
+        client.environment = Environment::PRODUCTION
         client
       end
     end
 
     def initialize
       @verification_url = ENV['IAP_VERIFICATION_ENDPOINT']
-      @env_name = ENV['IAP_VERIFICATION_ENVIRONMENT']
+      @environment = ENV['IAP_VERIFICATION_ENVIRONMENT']
     end
 
     def verify!(data, options = {})
       @verification_url ||= ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT
-      @env_name ||= Venice::Receipt::EnvName::DEVELOPMENT
+      @environment ||= Environment::DEVELOPMENT
       @shared_secret = options[:shared_secret] if options[:shared_secret]
       @exclude_old_transactions = options[:exclude_old_transactions] if options[:exclude_old_transactions]
 
       json = json_response_from_verifying_data(data, options)
-      json['env_name'] = env_name if json
+      json['environment'] = environment if json
 
       case json['status'].to_i
       when 0, 21006

--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -3,12 +3,9 @@ require 'net/https'
 require 'uri'
 
 module Venice
-  ITUNES_PRODUCTION_RECEIPT_VERIFICATION_ENDPOINT = 'https://buy.itunes.apple.com/verifyReceipt'
-  ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT = 'https://sandbox.itunes.apple.com/verifyReceipt'
-
-  module Environment
-    PRODUCTION = 'production'
-    DEVELOPMENT = 'development'
+  class Environment < Struct.new(:name, :endpoint)
+    PRODUCTION = new('production', 'https://buy.itunes.apple.com/verifyReceipt')
+    DEVELOPMENT = new('development', 'https://sandbox.itunes.apple.com/verifyReceipt')
   end
 
   class Client
@@ -19,15 +16,15 @@ module Venice
     class << self
       def development
         client = new
-        client.verification_url = ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT
-        client.environment = Environment::DEVELOPMENT
+        client.verification_url = Environment::DEVELOPMENT.endpoint
+        client.environment = Environment::DEVELOPMENT.name
         client
       end
 
       def production
         client = new
-        client.verification_url = ITUNES_PRODUCTION_RECEIPT_VERIFICATION_ENDPOINT
-        client.environment = Environment::PRODUCTION
+        client.verification_url = Environment::PRODUCTION.endpoint
+        client.environment = Environment::PRODUCTION.name
         client
       end
     end
@@ -38,8 +35,8 @@ module Venice
     end
 
     def verify!(data, options = {})
-      @verification_url ||= ITUNES_DEVELOPMENT_RECEIPT_VERIFICATION_ENDPOINT
-      @environment ||= Environment::DEVELOPMENT
+      @verification_url ||= Environment::DEVELOPMENT.endpoint
+      @environment ||= Environment::DEVELOPMENT.name
       @shared_secret = options[:shared_secret] if options[:shared_secret]
       @exclude_old_transactions = options[:exclude_old_transactions] if options[:exclude_old_transactions]
 

--- a/lib/venice/environment.rb
+++ b/lib/venice/environment.rb
@@ -1,0 +1,6 @@
+module Venice
+  class Environment < Struct.new(:name, :endpoint)
+    PRODUCTION = new('production', 'https://buy.itunes.apple.com/verifyReceipt')
+    DEVELOPMENT = new('development', 'https://sandbox.itunes.apple.com/verifyReceipt')
+  end
+end

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -4,11 +4,6 @@ module Venice
   class Receipt
     MAX_RE_VERIFY_COUNT = 3
 
-    module EnvName
-      DEVELOPMENT = 'development'
-      PRODUCTION = 'production'
-    end
-
     # For detailed explanations on these keys/values, see
     # https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW1
 
@@ -47,13 +42,13 @@ module Venice
     attr_reader :pending_renewal_info
 
     # The environment on which the receipt has verified against
-    attr_reader :env_name
+    attr_reader :environment
 
     def initialize(original_json_response = {})
       attributes = original_json_response['receipt']
 
       @original_json_response = original_json_response
-      @env_name = original_json_response['env_name']
+      @environment = original_json_response['environment']
       @bundle_id = attributes['bundle_id']
       @application_version = attributes['application_version']
       @original_application_version = attributes['original_application_version']
@@ -106,16 +101,16 @@ module Venice
     end
 
     def development?
-      env_name == Venice::Receipt::EnvName::DEVELOPMENT
+      environment == Environment::DEVELOPMENT
     end
 
     def production?
-      env_name == Venice::Receipt::EnvName::PRODUCTION
+      environment == Environment::PRODUCTION
     end
 
     def to_hash
       {
-        env_name: @env_name,
+        environment: @environment,
         bundle_id: @bundle_id,
         application_version: @application_version,
         original_application_version: @original_application_version,

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -41,9 +41,13 @@ module Venice
     # Information about the status of the customer's auto-renewable subscriptions
     attr_reader :pending_renewal_info
 
+    # The environment on which the receipt has verified against
+    attr_reader :env_name
+
     def initialize(attributes = {})
       @original_json_response = attributes['original_json_response']
 
+      @env_name = attributes['env_name']
       @bundle_id = attributes['bundle_id']
       @application_version = attributes['application_version']
       @original_application_version = attributes['original_application_version']
@@ -59,7 +63,8 @@ module Venice
       @download_id = attributes['download_id']
       @requested_at = DateTime.parse(attributes['request_date']) if attributes['request_date']
       @receipt_created_at = DateTime.parse(attributes['receipt_creation_date']) if attributes['receipt_creation_date']
-      @expiration_intent = Integer(original_json_response['expiration_intent']) if original_json_response['expiration_intent']
+
+      @expiration_intent = Integer(original_json_response['expiration_intent']) if original_json_response && original_json_response['expiration_intent']
 
       @in_app = []
       if attributes['in_app']

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -83,6 +83,7 @@ module Venice
 
     def to_hash
       {
+        env_name: @env_name,
         bundle_id: @bundle_id,
         application_version: @application_version,
         original_application_version: @original_application_version,

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -101,11 +101,11 @@ module Venice
     end
 
     def development?
-      environment == Environment::DEVELOPMENT
+      environment == Environment::DEVELOPMENT.name
     end
 
     def production?
-      environment == Environment::PRODUCTION
+      environment == Environment::PRODUCTION.name
     end
 
     def to_hash

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -4,6 +4,11 @@ module Venice
   class Receipt
     MAX_RE_VERIFY_COUNT = 3
 
+    module EnvName
+      DEVELOPMENT = 'development'
+      PRODUCTION = 'production'
+    end
+
     # For detailed explanations on these keys/values, see
     # https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW1
 
@@ -79,6 +84,14 @@ module Venice
           @pending_renewal_info << PendingRenewalInfo.new(pending_renewal_attributes)
         end
       end
+    end
+
+    def development?
+      env_name == Venice::Receipt::EnvName::DEVELOPMENT
+    end
+
+    def production?
+      env_name == Venice::Receipt::EnvName::PRODUCTION
     end
 
     def to_hash

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -106,7 +106,7 @@ describe Venice::Client do
       it 'should create a latest receipt' do
         expect(client).to receive(:json_response_from_verifying_data).and_return(response)
         receipt = client.verify! 'asdf'
-        expect(receipt.env_name).to eq 'development'
+        expect(receipt.environment).to eq 'development'
         expect(receipt.latest_receipt_info).not_to be_nil
         expect(receipt.latest_receipt_info.first.product_id).to eq 'com.ficklebits.nsscreencast.monthly_sub'
       end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -7,7 +7,7 @@ describe Venice::Client do
   describe '#verify!' do
     context 'with a receipt response' do
       before do
-        client.stub(:json_response_from_verifying_data).and_return(response)
+        expect(client).to receive(:json_response_from_verifying_data).and_return(response)
       end
 
       let(:response) do
@@ -26,12 +26,12 @@ describe Venice::Client do
     context 'no shared_secret' do
       before do
         client.shared_secret = nil
-        Venice::Receipt.stub :new
+        expect(Venice::Receipt).to receive(:new)
       end
 
       it 'should only include the receipt_data' do
-        Net::HTTP.any_instance.should_receive(:request) do |post|
-          post.body.should eq({ 'receipt-data' => receipt_data }.to_json)
+        expect_any_instance_of(Net::HTTP).to receive(:request) do |post|
+          expect(post.body).to eq({ 'receipt-data' => receipt_data }.to_json)
           post
         end
         client.verify! receipt_data
@@ -42,7 +42,7 @@ describe Venice::Client do
       let(:secret) { 'shhhhhh' }
 
       before do
-        Venice::Receipt.stub :new
+        expect(Venice::Receipt).to receive(:new)
       end
 
       context 'set secret manually' do
@@ -51,8 +51,8 @@ describe Venice::Client do
         end
 
         it 'should include the secret in the post' do
-          Net::HTTP.any_instance.should_receive(:request) do |post|
-            post.body.should eq({ 'receipt-data' => receipt_data, 'password' => secret }.to_json)
+          expect_any_instance_of(Net::HTTP).to receive(:request) do |post|
+            expect(post.body).to eq({ 'receipt-data' => receipt_data, 'password' => secret }.to_json)
             post
           end
           client.verify! receipt_data
@@ -63,8 +63,8 @@ describe Venice::Client do
         let(:options) { { shared_secret: secret } }
 
         it 'should include the secret in the post' do
-          Net::HTTP.any_instance.should_receive(:request) do |post|
-            post.body.should eq({ 'receipt-data' => receipt_data, 'password' => secret }.to_json)
+          expect_any_instance_of(Net::HTTP).to receive(:request) do |post|
+            expect(post.body).to eq({ 'receipt-data' => receipt_data, 'password' => secret }.to_json)
             post
           end
           client.verify! receipt_data, options
@@ -104,27 +104,27 @@ describe Venice::Client do
       end
 
       it 'should create a latest receipt' do
-        client.stub(:json_response_from_verifying_data).and_return(response)
+        expect(client).to receive(:json_response_from_verifying_data).and_return(response)
         receipt = client.verify! 'asdf'
-        receipt.env_name.should eq 'development'
-        receipt.latest_receipt_info.should_not be_nil
-        receipt.latest_receipt_info.first.product_id.should eq 'com.ficklebits.nsscreencast.monthly_sub'
+        expect(receipt.env_name).to eq 'development'
+        expect(receipt.latest_receipt_info).not_to be_nil
+        expect(receipt.latest_receipt_info.first.product_id).to eq 'com.ficklebits.nsscreencast.monthly_sub'
       end
 
       context 'when latest_receipt_info is a hash instead of an array' do
         it 'should still create a latest receipt' do
           response['latest_receipt_info'] = response['latest_receipt_info'].first
-          client.stub(:json_response_from_verifying_data).and_return(response)
+          expect(client).to receive(:json_response_from_verifying_data).and_return(response)
           receipt = client.verify! 'asdf'
-          receipt.latest_receipt_info.should_not be_nil
-          receipt.latest_receipt_info.first.product_id.should eq 'com.ficklebits.nsscreencast.monthly_sub'
+          expect(receipt.latest_receipt_info).not_to be_nil
+          expect(receipt.latest_receipt_info.first.product_id).to eq 'com.ficklebits.nsscreencast.monthly_sub'
         end
       end
     end
 
     context 'with an error response' do
       before do
-        client.stub(:json_response_from_verifying_data).and_return(response)
+        expect(client).to receive(:json_response_from_verifying_data).and_return(response)
       end
 
       let(:response) do
@@ -147,7 +147,7 @@ describe Venice::Client do
 
     context 'with a retryable error response' do
       before do
-        client.stub(:json_response_from_verifying_data).and_return(response)
+        expect(client).to receive(:json_response_from_verifying_data).and_return(response)
       end
 
       let(:response) do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -106,6 +106,7 @@ describe Venice::Client do
       it 'should create a latest receipt' do
         client.stub(:json_response_from_verifying_data).and_return(response)
         receipt = client.verify! 'asdf'
+        receipt.env_name.should eq 'development'
         receipt.latest_receipt_info.should_not be_nil
         receipt.latest_receipt_info.first.product_id.should eq 'com.ficklebits.nsscreencast.monthly_sub'
       end

--- a/spec/fixtures/receipt_not_expired_cancelled.json
+++ b/spec/fixtures/receipt_not_expired_cancelled.json
@@ -34,18 +34,16 @@
         "expires_date": "2014-06-28 14:47:53 Etc/GMT",
         "is_trial_period": "false"
       }
-    ],
-    "original_json_response": {
-      "pending_renewal_info": [
-        {
-          "auto_renew_product_id": "com.foo.product1",
-          "original_transaction_id": "37xxxxxxxxx89",
-          "product_id": "com.foo.product1",
-          "auto_renew_status": "0",
-          "is_in_billing_retry_period": "0",
-          "expiration_intent": "1"
-        }
-      ]
+    ]
+  },
+  "pending_renewal_info": [
+    {
+      "auto_renew_product_id": "com.foo.product1",
+      "original_transaction_id": "37xxxxxxxxx89",
+      "product_id": "com.foo.product1",
+      "auto_renew_status": "0",
+      "is_in_billing_retry_period": "0",
+      "expiration_intent": "1"
     }
-  }
+  ]
 }

--- a/spec/in_app_receipt_spec.rb
+++ b/spec/in_app_receipt_spec.rb
@@ -42,19 +42,19 @@ describe Venice::InAppReceipt do
     its(:original_json_data) { attributes }
 
     it "should parse the 'original' attributes" do
-      subject.original.should be_instance_of Venice::InAppReceipt
-      subject.original.transaction_id.should == '140xxx867509'
-      subject.original.purchased_at.should be_instance_of DateTime
+      expect(subject.original).to be_instance_of Venice::InAppReceipt
+      expect(subject.original.transaction_id).to eq '140xxx867509'
+      expect(subject.original.purchased_at).to be_instance_of DateTime
     end
 
     it 'should parse expires_date when expires_date_ms is missing and expires_date is the ms epoch' do
       attributes.delete('expires_date_ms')
       attributes['expires_date'] = '1403941685000'
-      in_app_receipt.expires_at.should eq Time.at(1403941685000 / 1000)
+      expect(in_app_receipt.expires_at).to eq Time.at(1403941685000 / 1000)
     end
 
     it 'should output a hash with attributes' do
-      in_app_receipt.to_h.should include(quantity: 1,
+      expect(in_app_receipt.to_h).to include(quantity: 1,
                                          product_id: 'com.foo.product1',
                                          transaction_id: '1000000070107235',
                                          web_order_line_item_id: '1000000026812043',

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -68,6 +68,10 @@ describe Venice::Receipt do
           end
 
           its(:env_name) { is_expected.to eq 'production' }
+
+          its(:production?) { is_expected.to be true }
+
+          its(:development?) { is_expected.to be false }
         end
 
         context 'with 4 retryable error responses' do
@@ -122,6 +126,10 @@ describe Venice::Receipt do
           end
 
           its(:env_name) { is_expected.to eq 'development' }
+
+          its(:production?) { is_expected.to be false }
+
+          its(:development?) { is_expected.to be true }
         end
       end
 

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -47,7 +47,7 @@ describe Venice::Receipt do
         expect(subject).to be_an_instance_of(Venice::Receipt)
       end
 
-      its(:env_name) { is_expected.to eq 'production' }
+      its(:environment) { is_expected.to eq 'production' }
 
       describe 'retrying VerificationError' do
         let(:retryable_error_response) do
@@ -67,10 +67,8 @@ describe Venice::Receipt do
             expect(subject).to be_an_instance_of(Venice::Receipt)
           end
 
-          its(:env_name) { is_expected.to eq 'production' }
-
+          its(:environment) { is_expected.to eq 'production' }
           its(:production?) { is_expected.to be true }
-
           its(:development?) { is_expected.to be false }
         end
 
@@ -91,9 +89,9 @@ describe Venice::Receipt do
         context 'with a not retryable error response' do
           let(:error_response) do
             {
-                'status' => 21000,
-                'receipt' => {},
-                'is_retryable' => false
+              'status' => 21000,
+              'receipt' => {},
+              'is_retryable' => false
             }
           end
 
@@ -125,10 +123,8 @@ describe Venice::Receipt do
             expect(subject).to be_an_instance_of(Venice::Receipt)
           end
 
-          its(:env_name) { is_expected.to eq 'development' }
-
+          its(:environment) { is_expected.to eq 'development' }
           its(:production?) { is_expected.to be false }
-
           its(:development?) { is_expected.to be true }
         end
       end

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -29,12 +29,12 @@ describe Venice::Receipt do
       subject { described_class.verify!('asdf') }
 
       before do
-        Venice::Client.any_instance.stub(:json_response_from_verifying_data).and_return(response)
+        allow_any_instance_of(Venice::Client).to receive(:json_response_from_verifying_data).and_return(response)
       end
 
       def stub_json_response_from_verifying_data(returns)
         counter = 0
-        Venice::Client.any_instance.stub(:json_response_from_verifying_data) do
+        allow_any_instance_of(Venice::Client).to receive(:json_response_from_verifying_data) do
           begin
             returns[counter].call
           ensure
@@ -60,7 +60,7 @@ describe Venice::Receipt do
 
         context 'with a retryable error response' do
           before do
-            Venice::Client.any_instance.stub(:json_response_from_verifying_data).and_return(retryable_error_response, response)
+            allow_any_instance_of(Venice::Client).to receive(:json_response_from_verifying_data).and_return(retryable_error_response, response)
           end
 
           it 'creates the receipt' do
@@ -76,7 +76,7 @@ describe Venice::Receipt do
 
         context 'with 4 retryable error responses' do
           before do
-            Venice::Client.any_instance.stub(:json_response_from_verifying_data).and_return(
+            allow_any_instance_of(Venice::Client).to receive(:json_response_from_verifying_data).and_return(
               retryable_error_response,
               retryable_error_response,
               retryable_error_response,
@@ -98,7 +98,7 @@ describe Venice::Receipt do
           end
 
           before do
-            Venice::Client.any_instance.stub(:json_response_from_verifying_data).and_return(error_response, response)
+            allow_any_instance_of(Venice::Client).to receive(:json_response_from_verifying_data).and_return(error_response, response)
           end
 
           it { expect { subject }.to raise_error(Venice::Receipt::VerificationError) }

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -4,7 +4,7 @@ describe Venice::Receipt do
   describe 'parsing the response' do
     let(:response) { JSON.parse(File.read('./spec/fixtures/receipt_not_expired_cancelled.json')) }
 
-    subject { Venice::Receipt.new(response['receipt']) }
+    subject { Venice::Receipt.new(response) }
 
     its(:bundle_id) { 'com.foo.bar' }
     its(:application_version) { '2' }


### PR DESCRIPTION
Everything from https://github.com/nomad/venice/pull/76
> This PR is to expose the environment name on which the receipt has validated against.
>
> This is mainly because apple does not always return iOS 7 style receipts containing the environment name. The iOS 6 style receipts do not contain that information

Everything from https://github.com/nomad/venice/pull/77
> This is to be able to initialize receipt from response without any additional processing outside the constructor.

Plus:
- all fixes suggested by maintainer on those PRs
- removed rspec deprecation warnings

The mentioned PRs were stale despite the changes being useful. So I decided to finish that work and resubmit as a new PR.