### PR TITLE
Add missing fields in pending renewal info

### DIFF
--- a/lib/venice/pending_renewal_info.rb
+++ b/lib/venice/pending_renewal_info.rb
@@ -35,6 +35,9 @@ module Venice
     # This key is only present for apps that have Billing Grace Period enabled and when the user experiences a billing error at the time of renewal.
     attr_reader :grace_period_expires_at
 
+    # The transaction identifier of the original purchase.
+    attr_reader :original_transaction_id
+
     def initialize(attributes)
       @original_json_data = attributes
       @expiration_intent = Integer(attributes['expiration_intent']) if attributes['expiration_intent']
@@ -50,6 +53,7 @@ module Venice
       @price_consent_status = Integer(attributes['price_consent_status']) if attributes['price_consent_status']
       @cancellation_reason = Integer(attributes['cancellation_reason']) if attributes['cancellation_reason']
       @grace_period_expires_at = DateTime.parse(attributes['grace_period_expires_date']) if attributes['grace_period_expires_date']
+      @original_transaction_id = attributes['original_transaction_id'] if attributes['original_transaction_id']
     end
 
     def to_hash
@@ -62,6 +66,7 @@ module Venice
         price_consent_status: @price_consent_status,
         cancellation_reason: @cancellation_reason,
         grace_period_expires_at: (@grace_period_expires_at.httpdate rescue nil),
+        original_transaction_id: @original_transaction_id,
       }
     end
 

--- a/lib/venice/pending_renewal_info.rb
+++ b/lib/venice/pending_renewal_info.rb
@@ -31,6 +31,10 @@ module Venice
     # Use this value along with the cancellation date to identify possible issues in your app that may lead customers to contact Apple customer support.
     attr_reader :cancellation_reason
 
+    # The time at which the grace period for subscription renewals expires, in a date-time format similar to the ISO 8601.
+    # This key is only present for apps that have Billing Grace Period enabled and when the user experiences a billing error at the time of renewal.
+    attr_reader :grace_period_expires_at
+
     def initialize(attributes)
       @original_json_data = attributes
       @expiration_intent = Integer(attributes['expiration_intent']) if attributes['expiration_intent']
@@ -45,6 +49,7 @@ module Venice
 
       @price_consent_status = Integer(attributes['price_consent_status']) if attributes['price_consent_status']
       @cancellation_reason = Integer(attributes['cancellation_reason']) if attributes['cancellation_reason']
+      @grace_period_expires_at = DateTime.parse(attributes['grace_period_expires_date']) if attributes['grace_period_expires_date']
     end
 
     def to_hash
@@ -55,7 +60,8 @@ module Venice
         is_in_billing_retry_period: @is_in_billing_retry_period,
         product_id: @product_id,
         price_consent_status: @price_consent_status,
-        cancellation_reason: @cancellation_reason
+        cancellation_reason: @cancellation_reason,
+        grace_period_expires_at: (@grace_period_expires_at.httpdate rescue nil),
       }
     end
 

--- a/spec/pending_renewal_info_spec.rb
+++ b/spec/pending_renewal_info_spec.rb
@@ -33,7 +33,9 @@ describe Venice::PendingRenewalInfo do
                                      is_in_billing_retry_period: false,
                                      product_id: 'com.foo.product1',
                                      price_consent_status: nil,
-                                     cancellation_reason: nil)
+                                     cancellation_reason: nil,
+                                     grace_period_expires_at: nil,
+                                 )
     end
   end
 end

--- a/spec/pending_renewal_info_spec.rb
+++ b/spec/pending_renewal_info_spec.rb
@@ -35,6 +35,7 @@ describe Venice::PendingRenewalInfo do
                                      price_consent_status: nil,
                                      cancellation_reason: nil,
                                      grace_period_expires_at: nil,
+                                     original_transaction_id: "37xxxxxxxxx89",
                                  )
     end
   end

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -174,6 +174,7 @@ describe Venice::Receipt do
                                                                price_consent_status: nil,
                                                                cancellation_reason: nil,
                                                                grace_period_expires_at: nil,
+                                                               original_transaction_id: "37xxxxxxxxx89",
                                                              }])
     end
   end

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -172,7 +172,9 @@ describe Venice::Receipt do
                                                                is_in_billing_retry_period: false,
                                                                product_id: 'com.foo.product1',
                                                                price_consent_status: nil,
-                                                               cancellation_reason: nil }])
+                                                               cancellation_reason: nil,
+                                                               grace_period_expires_at: nil,
+                                                             }])
     end
   end
 end


### PR DESCRIPTION
## Issue

Compared to [Apples' guide of pending renewal info](https://developer.apple.com/documentation/appstorereceipts/responsebody/pending_renewal_info
), I found those missing fields below.

- `grace_period_expires_date`
- `grace_period_expires_date_ms`
- `grace_period_expires_date_pst`
- `original_transaction_id`

## Changes

I added the missing fields into `Venice::PendingRenewalInfo`.

1. `grace_period_expires_at`
   - It doubles `grace_period_expires_date`, `grace_period_expires_date_ms`, and `grace_period_expires_date_pst`.
2. `original_transaction_id`