### PR TITLE
Fix not to raise error when calling Receipt.new with no args

### DIFF
--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -44,7 +44,7 @@ module Venice
     # The environment on which the receipt has verified against
     attr_reader :environment
 
-    def initialize(original_json_response = {})
+    def initialize(original_json_response = {'receipt' => {}})
       attributes = original_json_response['receipt']
 
       @original_json_response = original_json_response

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -178,4 +178,12 @@ describe Venice::Receipt do
                                                              }])
     end
   end
+
+  describe 'initialize with no argument' do
+    subject { Venice::Receipt.new }
+
+    it 'does not raise error' do
+      expect { subject }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Currently, `Receipt#initialize` accepts one argument, and default value is set as empty hash. By [this change](https://github.com/qsona/venice/commit/9fc0b8f6de8e8db3cf429a3773d048cb9de04365#diff-7fc1bb8d0b22c4f9edc11d8630fd01f2L44-R48), `undefined method '[]' for nil:NilClass` error is raised when `Receipt.new` (with no args) is called, so I fixed it.

This PR just fixes to keep a behaviour on v0.5.0. Otherwise, I think the default argument should not be specified.